### PR TITLE
Set CLOUDLAUNCH_PATH_PREFIX in supervisor config

### DIFF
--- a/roles/cloudlaunch/templates/supervisor_config_cloudlaunch.j2
+++ b/roles/cloudlaunch/templates/supervisor_config_cloudlaunch.j2
@@ -1,5 +1,6 @@
 [program:cloudlaunch]
 command={{ server_install_dir }}/.venv/bin/gunicorn cloudlaunchserver.wsgi:application --bind 127.0.0.1:8000 --pid /var/run/cloudlaunch/gunicorn.pid --workers 4
+environment=CLOUDLAUNCH_PATH_PREFIX="/cloudlaunch"
 user={{ system_user }}
 directory={{ server_install_dir }}/django-cloudlaunch
 stdout_logfile={{ log_dir }}gunicorn_stdout.log


### PR DESCRIPTION
This PR sets the CLOUDLAUNCH_PATH_PREFIX environment variable which was added in the fix for galaxyproject/cloudlaunch#146.

Note: I haven't tested this this should do the trick.